### PR TITLE
Wikidoc: modified comment for redef fun standard::Object::==

### DIFF
--- a/lib/standard/kernel.nit
+++ b/lib/standard/kernel.nit
@@ -36,7 +36,7 @@ interface Object
 	fun is_same_type(other: Object): Bool is intern
 
 	# Have `self' and `other' the same value?
-	##
+	# sdad
 	# The exact meaning of "same value" is let to the subclasses.
 	# Implicitly, the default implementation, is `is'
 	fun ==(other: nullable Object): Bool do return self is other


### PR DESCRIPTION
Wikidoc: modified comment for redef fun standard::Object::==

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
