### PR TITLE
Wikidoc: modified comment for redef fun standard::Collection[E]::is_empty

### DIFF
--- a/lib/standard/collection/abstract_collection.nit
+++ b/lib/standard/collection/abstract_collection.nit
@@ -53,7 +53,7 @@ interface Collection[E]
 		end
 	end
 
-	# Is there no item in the collection ?
+	# Is there no item in the collection ?c
 	fun is_empty: Bool is abstract 
 
 	# Number of items in the collection.


### PR DESCRIPTION
Wikidoc: modified comment for redef fun standard::Collection[E]::is_empty

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
