### PR TITLE
Wikidoc: modified comment for abstract class standard::AbstractString

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -21,7 +21,7 @@ import hash
 # String                                                                      #
 ###############################################################################
 
-# Common subclass for String and Buffer
+# Common subclass for String and Buffertest
 abstract class AbstractString
 	super AbstractArrayRead[Char]
 


### PR DESCRIPTION
Wikidoc: modified comment for abstract class standard::AbstractString

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
