### PR TITLE
Wikidoc: added comment for standard::array::ArrayMapKeys

### DIFF
--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -609,6 +609,7 @@ class ArrayMap[K: Object, E]
 	end
 end
 
+# test
 class ArrayMapKeys[K: Object, E]
 	super RemovableCollection[K]
 	# The original map


### PR DESCRIPTION
Wikidoc: added comment for standard::array::ArrayMapKeys

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
