### PR TITLE
Wikidoc: added comment for standard::array::Array::[]

### DIFF
--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -276,6 +276,7 @@ class Array[E]
 		end
 	end
 
+	# Performances optimizations
 	redef fun [](index)
 	do
 		assert index: index >= 0 and index < _length


### PR DESCRIPTION
Wikidoc: added comment for standard::array::Array::[]

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
