### PR TITLE
Wikidoc: modified comment for standard::array::AbstractArray

### DIFF
--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -153,7 +153,7 @@ abstract class AbstractArrayRead[E]
 	end
 end
 
-# Resizable one dimension array of objects.
+# Resizable one dimension array of objects.test
 abstract class AbstractArray[E]
 	super AbstractArrayRead[E]
 	super Sequence[E]


### PR DESCRIPTION
Wikidoc: modified comment for standard::array::AbstractArray

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
