### PR TITLE
Wikidoc: modified comment for standard::array::AbstractArray

### DIFF
--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -154,6 +154,7 @@ abstract class AbstractArrayRead[E]
 end
 
 # Resizable one dimension array of objects.
+# etst
 abstract class AbstractArray[E]
 	super AbstractArrayRead[E]
 	super Sequence[E]


### PR DESCRIPTION
Wikidoc: modified comment for standard::array::AbstractArray

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
